### PR TITLE
fix(ci): Remove DockerHub login and publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,26 +8,26 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-      
+          python-version: "3.11"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install poetry
           poetry install --no-root --with dev
-      
+
       - name: Run linter
         run: |
           poetry run ruff check .
-      
+
       - name: Run tests
         run: |
           poetry run pytest
@@ -35,27 +35,27 @@ jobs:
   docker:
     needs: test
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -67,7 +67,7 @@ jobs:
             type=ref,event=branch
             type=sha
             type=raw,value=${{ github.ref_name }}
-      
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
This pull request makes minor adjustments to the `.github/workflows/release.yml` file. The most important change is commenting out the Docker Hub login step, which prevents the workflow from attempting to log in to Docker Hub. There is also a small formatting update for the Python version specification.

Workflow configuration changes:

* Commented out the Docker Hub login step, disabling authentication to Docker Hub in the release workflow.
* Changed the formatting of the Python version value from single to double quotes in the setup step.