### PR TITLE
fix(deploy): Add env vars support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install poetry
-          poetry install --no-root --with dev
-
-      - name: Run linter
-        run: |
-          poetry run ruff check .
+          poetry install --with dev
 
       - name: Run tests
         run: |
@@ -55,3 +51,26 @@ jobs:
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
+
+  lint:
+    name: Lint code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install --with lint
+
+      - name: Run Ruff linter
+        run: |
+          poetry run ruff check .

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,11 @@ RUN poetry config virtualenvs.create false \
 # Copy application code
 COPY . .
 
-# Expose port
-EXPOSE 6666
+# Expose ZMQ ports (CA listener + registration listener)
+EXPOSE 5000 5001
 
-# Run the CA server
-CMD ["python", "ca_server.py"]
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=10 \
+    CMD python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('127.0.0.1', 5000)); s.close()"
+
+# Default command: auto-bootstrap (init on first boot) + run both listeners
+CMD ["python", "ca_server.py", "start"]

--- a/ca_server.py
+++ b/ca_server.py
@@ -255,28 +255,28 @@ class CAServer(Common):
         env_seed: str | None = None,
         env_host: str = "0.0.0.0",
     ) -> bool:
-        """
-        Auto-bootstrap the CA and run both listeners concurrently.
+        """Auto-bootstrap the CA and run both listeners concurrently.
 
-        On **first boot** (no config file yet):
-          1. Injects *env_seed* into the config so it is used as the
-             registration seed instead of generating a random one.
-          2. Runs ``init_pki()`` to create the CA key/certificate.
+        On first boot (no config file yet), injects env_seed into the config
+        so it is used as the registration seed instead of generating a random
+        one, then calls init_pki() to create the CA key and certificate.
 
-        On **subsequent boots** (config + CA key/cert already exist on the
-        data volume):
-          - ``init_pki()`` is idempotent and skips key/cert generation.
+        On subsequent boots (config and CA key/cert already exist on the data
+        volume), init_pki() is idempotent and skips key/cert generation.
 
-        Regardless of boot type, both the **registration listener**
-        (port + 1) and the **CA listener** (port) are started and the
-        process is kept alive.
+        Regardless of boot type, both the registration listener (port + 1)
+        and the CA listener (port) are started and the process is kept alive.
 
         Args:
-            env_seed: Registration seed from the ``UPKI_CA_SEED`` env var.
-            env_host: Bind address (default ``0.0.0.0`` for Docker).
+            env_seed: Registration seed from the UPKI_CA_SEED environment
+                variable. Ignored when the config already contains a seed.
+            env_host: Bind address for both ZMQ sockets. Defaults to
+                ``0.0.0.0`` so Docker containers can accept connections
+                from other containers.
 
         Returns:
-            bool: This method never returns normally; it loops indefinitely.
+            bool: Always False on error; does not return normally on success
+                (blocks in an infinite sleep loop).
         """
         try:
             # Pre-load config; inject env seed before any init so that
@@ -299,7 +299,7 @@ class CAServer(Common):
             # init_pki() leaves self._authority initialised with its storage.
             storage = self._authority.storage
 
-            # ── Registration listener (port + 1) ─────────────────────────────
+            # -- Registration listener (port + 1) ----------------------------
             self._register_listener = ZMQRegister(
                 host=host,
                 port=port + 1,
@@ -311,7 +311,7 @@ class CAServer(Common):
             self._register_listener.start()
             self._logger.info(f"Registration listener started on {host}:{port + 1}")
 
-            # ── CA listener (port) ─────────────────────────────────────────────
+            # -- CA listener (port) -------------------------------------------
             self._listener = ZMQListener(host=host, port=port, storage=storage)
             self._listener.initialize()
             self._listener.initialize_authority()

--- a/ca_server.py
+++ b/ca_server.py
@@ -21,6 +21,7 @@ import os
 import secrets
 import signal
 import sys
+import time
 
 from upki_ca.ca.authority import Authority
 from upki_ca.connectors.zmq_listener import ZMQListener
@@ -249,6 +250,82 @@ class CAServer(Common):
             self._logger.error("CA Server", e)
             return False
 
+    def start(
+        self,
+        env_seed: str | None = None,
+        env_host: str = "0.0.0.0",
+    ) -> bool:
+        """
+        Auto-bootstrap the CA and run both listeners concurrently.
+
+        On **first boot** (no config file yet):
+          1. Injects *env_seed* into the config so it is used as the
+             registration seed instead of generating a random one.
+          2. Runs ``init_pki()`` to create the CA key/certificate.
+
+        On **subsequent boots** (config + CA key/cert already exist on the
+        data volume):
+          - ``init_pki()`` is idempotent and skips key/cert generation.
+
+        Regardless of boot type, both the **registration listener**
+        (port + 1) and the **CA listener** (port) are started and the
+        process is kept alive.
+
+        Args:
+            env_seed: Registration seed from the ``UPKI_CA_SEED`` env var.
+            env_host: Bind address (default ``0.0.0.0`` for Docker).
+
+        Returns:
+            bool: This method never returns normally; it loops indefinitely.
+        """
+        try:
+            # Pre-load config; inject env seed before any init so that
+            # init_pki() will not generate a new random seed.
+            self._config = Config(self._config_path())
+            self._config.load()
+            if env_seed and not self._config.get_seed():
+                self._config.set_seed(env_seed)
+
+            # Idempotent: generates CA key/cert only on first boot.
+            if not self.init_pki():
+                return False
+
+            port = self._config.get_port()
+            seed = self._config.get_seed() or "default_seed"
+            # Use env_host for binding so Docker containers can accept
+            # connections from other containers (0.0.0.0 vs 127.0.0.1).
+            host = env_host if env_host else self._config.get_host()
+
+            # init_pki() leaves self._authority initialised with its storage.
+            storage = self._authority.storage
+
+            # ── Registration listener (port + 1) ─────────────────────────────
+            self._register_listener = ZMQRegister(
+                host=host,
+                port=port + 1,
+                seed=seed,
+                authority=self._authority,
+            )
+            self._register_listener.initialize()
+            self._register_listener.bind()
+            self._register_listener.start()
+            self._logger.info(f"Registration listener started on {host}:{port + 1}")
+
+            # ── CA listener (port) ─────────────────────────────────────────────
+            self._listener = ZMQListener(host=host, port=port, storage=storage)
+            self._listener.initialize()
+            self._listener.initialize_authority()
+            self._listener.bind()
+            self._listener.start()
+            self._logger.info(f"CA server started on {host}:{port}")
+
+            while True:
+                time.sleep(1)
+
+        except Exception as e:
+            self._logger.error("CA Server", e)
+            return False
+
     def stop(self) -> bool:
         """
         Stop the CA Server.
@@ -321,6 +398,12 @@ def main() -> int:
     # register command
     subparsers.add_parser("register", help="Register RA (clear mode)")
 
+    # start command (default Docker entrypoint: auto-init + run both listeners)
+    subparsers.add_parser(
+        "start",
+        help="Auto-bootstrap: init if needed, then run register + CA listeners",
+    )
+
     # listen command
     listen_parser = subparsers.add_parser("listen", help="Start CA server (TLS mode)")
     listen_parser.add_argument("--host", default="127.0.0.1", help="Host to bind to")
@@ -333,7 +416,13 @@ def main() -> int:
 
     # Create server
     server = CAServer()
-    server._storage_path = args.path
+
+    # CLI --path takes precedence; fall back to env var when not set.
+    env_data_dir = os.environ.get("UPKI_DATA_DIR")
+    server._storage_path = args.path or env_data_dir or None
+
+    env_seed = os.environ.get("UPKI_CA_SEED")
+    env_host = os.environ.get("UPKI_CA_HOST", "0.0.0.0")
 
     # Execute command
     if args.command == "init":
@@ -389,6 +478,13 @@ def main() -> int:
 
     elif args.command == "listen":
         if server.listen():
+            return 0
+        else:
+            print("CA server failed to start", file=sys.stderr)
+            return 1
+
+    elif args.command == "start":
+        if server.start(env_seed=env_seed, env_host=env_host):
             return 0
         else:
             print("CA server failed to start", file=sys.stderr)

--- a/poetry.lock
+++ b/poetry.lock
@@ -626,7 +626,7 @@ version = "0.15.6"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["lint"]
 files = [
     {file = "ruff-0.15.6-py3-none-linux_armv6l.whl", hash = "sha256:7c98c3b16407b2cf3d0f2b80c80187384bc92c6774d85fefa913ecd941256fff"},
     {file = "ruff-0.15.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee7dcfaad8b282a284df4aa6ddc2741b3f4a18b0555d626805555a820ea181c3"},
@@ -663,4 +663,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <4.0"
-content-hash = "8849669288c3809b903ca20f073e9bf7a6269b91654ff5b7548370b686ca9e6a"
+content-hash = "6820566681c81962ed65fa6670f044861753a10de258863bce6e22e07624f532"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,19 @@ dependencies = [
     "pyzmq (>=26.0.0,<27.0.0)"
 ]
 
+[tool.poetry.group.lint]
+optional = true
+
+[tool.poetry.group.lint.dependencies]
+ruff = ">=0.10.0,<1.0.0"
+
+[tool.poetry.group.dev]
+optional = true
+
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0.0,<9.0.0"
 pytest-cov = ">=6.0.0,<7.0.0"
 pytest-asyncio = ">=0.25.0,<1.0.0"
-ruff = ">=0.10.0,<1.0.0"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_100_pki_functional.py
+++ b/tests/test_100_pki_functional.py
@@ -1522,6 +1522,168 @@ class TestSubCAChain:
         ), f"Full chain (Root → Sub-CA → Leaf) validation failed:\n{r.stderr}"
 
 
+class TestStartCommand:
+    """Functional tests for the ca_server.py start command.
+
+    Verifies the auto-bootstrap behaviour introduced for Docker deployment:
+    - Both ZMQ ports (listener + registration) become reachable.
+    - The command is idempotent across restarts.
+    - The UPKI_CA_SEED environment variable is persisted to ca.config.yml.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self):
+        """Create and clean up a temporary PKI data directory."""
+        self.pki_path = "/tmp/test_pki_start"
+        self.ca_port = 15000
+        self.reg_port = 15001
+
+        if os.path.exists(self.pki_path):
+            shutil.rmtree(self.pki_path)
+
+        yield
+
+        if os.path.exists(self.pki_path):
+            shutil.rmtree(self.pki_path)
+
+    def _wait_for_port(self, host: str, port: int, timeout: float = 30.0) -> bool:
+        """Poll a TCP port until it is reachable or the timeout expires.
+
+        Args:
+            host: Target hostname or IP address.
+            port: Target TCP port number.
+            timeout: Maximum seconds to wait.
+
+        Returns:
+            bool: True if the port became reachable, False on timeout.
+        """
+        import socket
+        import time
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection((host, port), timeout=1):
+                    return True
+            except OSError:
+                time.sleep(0.5)
+        return False
+
+    def test_start_bootstraps_ca_and_opens_both_ports(self):
+        """Test that start opens port 15000 (CA) and port 15001 (registration).
+
+        Launches ca_server.py start as a subprocess, waits for both ZMQ TCP
+        sockets to become reachable, then terminates the process.
+        """
+        import yaml
+
+        env = os.environ.copy()
+        env["UPKI_CA_SEED"] = "functional-test-seed"
+        env["UPKI_CA_HOST"] = "127.0.0.1"
+
+        # Use non-default ports to avoid conflicts with a running CA instance.
+        os.makedirs(self.pki_path, exist_ok=True)
+        config_path = os.path.join(self.pki_path, "ca.config.yml")
+        with open(config_path, "w") as f:
+            yaml.safe_dump({"host": "127.0.0.1", "port": self.ca_port}, f)
+
+        proc = subprocess.Popen(
+            [sys.executable, CA_SERVER_PATH, "--path", self.pki_path, "start"],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        try:
+            ca_ready = self._wait_for_port("127.0.0.1", self.ca_port)
+            reg_ready = self._wait_for_port("127.0.0.1", self.reg_port)
+
+            assert (
+                ca_ready
+            ), f"CA listener on port {self.ca_port} never became reachable"
+            assert (
+                reg_ready
+            ), f"Registration listener on port {self.reg_port} never became reachable"
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+    def test_start_is_idempotent_on_restart(self):
+        """Test that re-running start on an existing PKI does not fail.
+
+        First init, then start on the same path; the seed in ca.config.yml
+        must remain unchanged after the second run.
+        """
+        import yaml
+
+        seed = "idempotency-test-seed"
+
+        # First pass: initialise PKI
+        result = subprocess.run(
+            [sys.executable, CA_SERVER_PATH, "--path", self.pki_path, "init"],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "UPKI_CA_SEED": seed},
+        )
+        assert result.returncode == 0, result.stderr
+
+        # Read the seed that was stored
+        config_path = os.path.join(self.pki_path, "ca.config.yml")
+        with open(config_path) as f:
+            stored_seed = yaml.safe_load(f).get("seed")
+
+        # Second pass: start (init is idempotent inside start)
+        env = os.environ.copy()
+        env["UPKI_CA_SEED"] = "different-seed-must-be-ignored"
+        env["UPKI_CA_HOST"] = "127.0.0.1"
+
+        proc = subprocess.Popen(
+            [sys.executable, CA_SERVER_PATH, "--path", self.pki_path, "start"],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        reachable = self._wait_for_port("127.0.0.1", 5000)
+        proc.terminate()
+        proc.wait(timeout=5)
+
+        assert reachable, "CA did not start on second run"
+
+        # Seed on disk must not have changed
+        with open(config_path) as f:
+            after_seed = yaml.safe_load(f).get("seed")
+        assert after_seed == stored_seed
+
+    def test_start_uses_provided_env_seed(self):
+        """Test that UPKI_CA_SEED is written to ca.config.yml on first boot."""
+        import yaml
+
+        expected_seed = "deterministic-seed-for-test"
+        env = os.environ.copy()
+        env["UPKI_CA_SEED"] = expected_seed
+        env["UPKI_CA_HOST"] = "127.0.0.1"
+
+        proc = subprocess.Popen(
+            [sys.executable, CA_SERVER_PATH, "--path", self.pki_path, "start"],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        reachable = self._wait_for_port("127.0.0.1", 5000)
+        proc.terminate()
+        proc.wait(timeout=5)
+
+        assert reachable, "CA did not start within timeout"
+
+        config_path = os.path.join(self.pki_path, "ca.config.yml")
+        assert os.path.exists(config_path), "ca.config.yml was not created"
+
+        with open(config_path) as f:
+            written_seed = yaml.safe_load(f).get("seed")
+        assert written_seed == expected_seed
+
+
 # Run tests if executed directly
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_100_pki_functional.py
+++ b/tests/test_100_pki_functional.py
@@ -1606,7 +1606,11 @@ class TestStartCommand:
             ), f"Registration listener on port {self.reg_port} never became reachable"
         finally:
             proc.terminate()
-            proc.wait(timeout=5)
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
 
     def test_start_is_idempotent_on_restart(self):
         """Test that re-running start on an existing PKI does not fail.
@@ -1637,15 +1641,23 @@ class TestStartCommand:
         env["UPKI_CA_SEED"] = "different-seed-must-be-ignored"
         env["UPKI_CA_HOST"] = "127.0.0.1"
 
+        # Overwrite config with custom port to avoid conflicts
+        with open(config_path, "w") as f:
+            yaml.safe_dump({"host": "127.0.0.1", "port": self.ca_port, "seed": stored_seed}, f)
+
         proc = subprocess.Popen(
             [sys.executable, CA_SERVER_PATH, "--path", self.pki_path, "start"],
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        reachable = self._wait_for_port("127.0.0.1", 5000)
+        reachable = self._wait_for_port("127.0.0.1", self.ca_port)
         proc.terminate()
-        proc.wait(timeout=5)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
 
         assert reachable, "CA did not start on second run"
 
@@ -1663,6 +1675,11 @@ class TestStartCommand:
         env["UPKI_CA_SEED"] = expected_seed
         env["UPKI_CA_HOST"] = "127.0.0.1"
 
+        os.makedirs(self.pki_path, exist_ok=True)
+        config_path = os.path.join(self.pki_path, "ca.config.yml")
+        with open(config_path, "w") as f:
+            yaml.safe_dump({"host": "127.0.0.1", "port": self.ca_port}, f)
+
         proc = subprocess.Popen(
             [sys.executable, CA_SERVER_PATH, "--path", self.pki_path, "start"],
             env=env,
@@ -1670,9 +1687,13 @@ class TestStartCommand:
             stderr=subprocess.PIPE,
         )
 
-        reachable = self._wait_for_port("127.0.0.1", 5000)
+        reachable = self._wait_for_port("127.0.0.1", self.ca_port)
         proc.terminate()
-        proc.wait(timeout=5)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
 
         assert reachable, "CA did not start within timeout"
 

--- a/tests/test_10_config.py
+++ b/tests/test_10_config.py
@@ -1,0 +1,79 @@
+"""
+Unit tests for Config.set_host().
+
+Author: uPKI Team
+License: MIT
+"""
+
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from upki_ca.utils.config import Config
+
+
+class TestConfigSetHost:
+    """Tests for Config.set_host() method."""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self):
+        """Create and clean up a temporary directory for each test."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.config_path = os.path.join(self.temp_dir, "ca.config.yml")
+        yield
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_should_set_host_and_get_host_returns_new_value(self):
+        """Test that set_host updates the value returned by get_host."""
+        # Arrange
+        config = Config(self.config_path)
+        config.load()
+
+        # Act
+        config.set_host("0.0.0.0")
+
+        # Assert
+        assert config.get_host() == "0.0.0.0"
+
+    def test_should_return_true_on_success(self):
+        """Test that set_host returns True on successful update."""
+        # Arrange
+        config = Config(self.config_path)
+        config.load()
+
+        # Act
+        result = config.set_host("0.0.0.0")
+
+        # Assert
+        assert result is True
+
+    def test_should_override_default_host(self):
+        """Test that set_host overrides the default value of 127.0.0.1."""
+        # Arrange
+        config = Config(self.config_path)
+        config.load()
+        assert config.get_host() == "127.0.0.1"
+
+        # Act
+        config.set_host("10.0.0.1")
+
+        # Assert
+        assert config.get_host() == "10.0.0.1"
+
+    def test_should_persist_host_after_save_and_reload(self):
+        """Test that the host value survives a save/reload cycle."""
+        # Arrange
+        config = Config(self.config_path)
+        config.load()
+
+        # Act
+        config.set_host("0.0.0.0")
+        config.save()
+
+        reloaded = Config(self.config_path)
+        reloaded.load()
+
+        # Assert
+        assert reloaded.get_host() == "0.0.0.0"

--- a/tests/test_20_ca_server.py
+++ b/tests/test_20_ca_server.py
@@ -1,0 +1,182 @@
+"""
+Unit tests for CAServer.start().
+
+Tests the auto-bootstrap behaviour introduced for Docker deployment.
+All ZMQ, Authority, and storage interactions are mocked so that no
+real PKI operations or network sockets are required.
+
+Author: uPKI Team
+License: MIT
+"""
+
+import os
+import shutil
+import tempfile
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from ca_server import CAServer
+
+
+class TestCAServerStart:
+    """Unit tests for CAServer.start() auto-bootstrap method."""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self):
+        """Create a temporary data directory and wire up the server."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.server = CAServer()
+        self.server._storage_path = self.temp_dir
+        yield
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _run_start(self, env_seed: str | None = None, env_host: str = "0.0.0.0"):
+        """Run CAServer.start() with mocked listeners that stop the loop.
+
+        ZMQListener.start is patched to raise SystemExit after being called
+        so that the infinite ``while True: time.sleep(1)`` loop exits cleanly
+        during tests.
+        """
+        mock_storage = MagicMock()
+        mock_authority = MagicMock()
+        mock_authority.storage = mock_storage
+
+        mock_register = MagicMock()
+        mock_listener = MagicMock()
+        # Make ZMQListener.start raise SystemExit so the loop terminates.
+        mock_listener.start.side_effect = SystemExit(0)
+
+        with (
+            patch("ca_server.FileStorage", return_value=mock_storage),
+            patch("ca_server.Authority") as mock_auth_cls,
+            patch("ca_server.ZMQRegister", return_value=mock_register),
+            patch("ca_server.ZMQListener", return_value=mock_listener),
+            patch("ca_server.time") as mock_time,
+        ):
+            mock_auth_cls.get_instance.return_value = mock_authority
+            mock_time.sleep.side_effect = SystemExit(0)
+
+            try:
+                self.server.start(env_seed=env_seed, env_host=env_host)
+            except SystemExit:
+                pass
+
+            return {
+                "storage": mock_storage,
+                "authority": mock_authority,
+                "register": mock_register,
+                "listener": mock_listener,
+                "auth_cls": mock_auth_cls,
+            }
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_should_inject_env_seed_when_config_has_no_seed(self):
+        """Test that env_seed is written to config when no seed exists yet."""
+        # Arrange — no pre-existing config file, so seed starts as None
+        env_seed = "my-bootstrap-seed-value"
+
+        # Act
+        self._run_start(env_seed=env_seed)
+
+        # Assert — config on disk must now contain the seed
+        from upki_ca.utils.config import Config
+
+        config = Config(os.path.join(self.temp_dir, "ca.config.yml"))
+        config.load()
+        assert config.get_seed() == env_seed
+
+    def test_should_not_override_existing_seed(self):
+        """Test that a pre-existing config seed is never overwritten."""
+        # Arrange — write a config with an existing seed first
+        from upki_ca.utils.config import Config
+
+        existing_seed = "existing-seed-must-not-change"
+        config = Config(os.path.join(self.temp_dir, "ca.config.yml"))
+        config.load()
+        config.set_seed(existing_seed)
+        config.save()
+
+        # Act — pass a different seed via env
+        self._run_start(env_seed="new-seed-should-be-ignored")
+
+        # Assert
+        reloaded = Config(os.path.join(self.temp_dir, "ca.config.yml"))
+        reloaded.load()
+        assert reloaded.get_seed() == existing_seed
+
+    def test_should_use_env_host_for_zmq_binding(self):
+        """Test that both ZMQ sockets bind to env_host, not 127.0.0.1."""
+        # Arrange
+        custom_host = "0.0.0.0"
+
+        mock_storage = MagicMock()
+        mock_authority = MagicMock()
+        mock_authority.storage = mock_storage
+        mock_register = MagicMock()
+        mock_listener = MagicMock()
+        mock_listener.start.side_effect = SystemExit(0)
+
+        with (
+            patch("ca_server.FileStorage", return_value=mock_storage),
+            patch("ca_server.Authority") as mock_auth_cls,
+            patch("ca_server.ZMQRegister", return_value=mock_register) as mock_reg_cls,
+            patch("ca_server.ZMQListener", return_value=mock_listener) as mock_lst_cls,
+            patch("ca_server.time"),
+        ):
+            mock_auth_cls.get_instance.return_value = mock_authority
+            try:
+                self.server.start(env_seed="seed", env_host=custom_host)
+            except SystemExit:
+                pass
+
+            # ZMQRegister must be created with custom_host
+            reg_call_kwargs = mock_reg_cls.call_args
+            assert reg_call_kwargs.kwargs["host"] == custom_host
+
+            # ZMQListener must be created with custom_host
+            lst_call_kwargs = mock_lst_cls.call_args
+            assert lst_call_kwargs.kwargs["host"] == custom_host
+
+    def test_should_call_init_pki_on_every_startup(self):
+        """Test that init_pki() is called each time start() runs (idempotent check)."""
+        # Act
+        with patch.object(self.server, "init_pki", return_value=False) as mock_init:
+            self.server.start(env_seed="seed")
+
+        # Assert — init_pki must have been called exactly once
+        mock_init.assert_called_once()
+
+    def test_should_start_both_listeners(self):
+        """Test that both the registration and CA listeners are started."""
+        # Arrange
+        mock_storage = MagicMock()
+        mock_authority = MagicMock()
+        mock_authority.storage = mock_storage
+        mock_register = MagicMock()
+        mock_listener = MagicMock()
+        mock_listener.start.side_effect = SystemExit(0)
+
+        with (
+            patch("ca_server.FileStorage", return_value=mock_storage),
+            patch("ca_server.Authority") as mock_auth_cls,
+            patch("ca_server.ZMQRegister", return_value=mock_register),
+            patch("ca_server.ZMQListener", return_value=mock_listener),
+            patch("ca_server.time"),
+        ):
+            mock_auth_cls.get_instance.return_value = mock_authority
+            try:
+                self.server.start(env_seed="seed")
+            except SystemExit:
+                pass
+
+        # Assert
+        mock_register.start.assert_called_once()
+        mock_listener.start.assert_called_once()

--- a/tests/test_20_ca_server.py
+++ b/tests/test_20_ca_server.py
@@ -9,10 +9,11 @@ Author: uPKI Team
 License: MIT
 """
 
+import contextlib
 import os
 import shutil
 import tempfile
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -61,10 +62,8 @@ class TestCAServerStart:
             mock_auth_cls.get_instance.return_value = mock_authority
             mock_time.sleep.side_effect = SystemExit(0)
 
-            try:
+            with contextlib.suppress(SystemExit):
                 self.server.start(env_seed=env_seed, env_host=env_host)
-            except SystemExit:
-                pass
 
             return {
                 "storage": mock_storage,
@@ -132,10 +131,8 @@ class TestCAServerStart:
             patch("ca_server.time"),
         ):
             mock_auth_cls.get_instance.return_value = mock_authority
-            try:
+            with contextlib.suppress(SystemExit):
                 self.server.start(env_seed="seed", env_host=custom_host)
-            except SystemExit:
-                pass
 
             # ZMQRegister must be created with custom_host
             reg_call_kwargs = mock_reg_cls.call_args
@@ -172,10 +169,8 @@ class TestCAServerStart:
             patch("ca_server.time"),
         ):
             mock_auth_cls.get_instance.return_value = mock_authority
-            try:
+            with contextlib.suppress(SystemExit):
                 self.server.start(env_seed="seed")
-            except SystemExit:
-                pass
 
         # Assert
         mock_register.start.assert_called_once()

--- a/upki_ca/utils/config.py
+++ b/upki_ca/utils/config.py
@@ -156,7 +156,9 @@ class Config(Common):
         # Validate clients mode
         clients = self._config.get("clients", "")
         if clients not in ClientModes:
-            raise ConfigurationError(f"Invalid clients mode: {clients}. Allowed: {ClientModes}")
+            raise ConfigurationError(
+                f"Invalid clients mode: {clients}. Allowed: {ClientModes}"
+            )
 
         # Validate key type
         key_type = self._config.get("key_type", "rsa")
@@ -186,6 +188,10 @@ class Config(Common):
     def get_host(self) -> str:
         """Get the listening host."""
         return self._config.get("host", "127.0.0.1")
+
+    def set_host(self, host: str) -> bool:
+        """Set the listening host."""
+        return self.set("host", host)
 
     def get_port(self) -> int:
         """Get the listening port."""


### PR DESCRIPTION
This pull request introduces an improved startup process for the CA server, making it more suitable for Docker deployments by enabling automatic initialization and concurrent startup of both the CA and registration listeners. It also adds support for environment-based configuration and improves maintainability with minor code cleanups.

**Dockerization and Startup Improvements:**

* The `Dockerfile` now exposes ports 5000 and 5001 for the CA and registration listeners, adds a healthcheck to verify the CA listener is up, and changes the default command to auto-bootstrap and run both listeners using the new `start` command.

**CA Server Enhancements:**

* A new `start` method is added to `CAServer`, which auto-bootstraps the CA on first boot (using an env-provided seed if available), ensures idempotent initialization, and starts both the registration and CA listeners concurrently.
* The CLI now includes a `start` subcommand, which is the default for Docker, and supports environment variables for data directory, seed, and host configuration. [[1]](diffhunk://#diff-b0a94ed9f1345daa5b551d46035f79c1a3143f1ecd77cd3e685216b417029dacR401-R406) [[2]](diffhunk://#diff-b0a94ed9f1345daa5b551d46035f79c1a3143f1ecd77cd3e685216b417029dacL336-R425) [[3]](diffhunk://#diff-b0a94ed9f1345daa5b551d46035f79c1a3143f1ecd77cd3e685216b417029dacR486-R492)

**Configuration Improvements:**

* The `Config` class now provides a `set_host` method, allowing the server to programmatically set the listening host, which is useful for Docker environments.

**Code Quality:**

* Minor formatting improvements are made for better readability and maintainability.