### PR TITLE
feat(ca): Handle static ca cert

### DIFF
--- a/ca_server.py
+++ b/ca_server.py
@@ -254,6 +254,8 @@ class CAServer(Common):
         self,
         env_seed: str | None = None,
         env_host: str = "0.0.0.0",
+        env_ca_key_file: str | None = None,
+        env_ca_cert_file: str | None = None,
     ) -> bool:
         """Auto-bootstrap the CA and run both listeners concurrently.
 
@@ -273,6 +275,12 @@ class CAServer(Common):
             env_host: Bind address for both ZMQ sockets. Defaults to
                 ``0.0.0.0`` so Docker containers can accept connections
                 from other containers.
+            env_ca_key_file: Path to an existing CA private key PEM file
+                (from UPKI_CA_KEY_FILE). Passed to init_pki() only on first
+                boot when the CA has not been initialised yet.
+            env_ca_cert_file: Path to an existing CA certificate PEM file
+                (from UPKI_CA_CERT_FILE). Passed to init_pki() only on first
+                boot when the CA has not been initialised yet.
 
         Returns:
             bool: Always False on error; does not return normally on success
@@ -287,7 +295,13 @@ class CAServer(Common):
                 self._config.set_seed(env_seed)
 
             # Idempotent: generates CA key/cert only on first boot.
-            if not self.init_pki():
+            # When UPKI_CA_KEY_FILE / UPKI_CA_CERT_FILE are provided and the
+            # CA is not yet initialised, import the supplied key/cert pair
+            # instead of generating a fresh one.
+            if not self.init_pki(
+                ca_key_path=env_ca_key_file,
+                ca_cert_path=env_ca_cert_file,
+            ):
                 return False
 
             port = self._config.get_port()
@@ -423,6 +437,8 @@ def main() -> int:
 
     env_seed = os.environ.get("UPKI_CA_SEED")
     env_host = os.environ.get("UPKI_CA_HOST", "0.0.0.0")
+    env_ca_key_file = os.environ.get("UPKI_CA_KEY_FILE")
+    env_ca_cert_file = os.environ.get("UPKI_CA_CERT_FILE")
 
     # Execute command
     if args.command == "init":
@@ -484,7 +500,12 @@ def main() -> int:
             return 1
 
     elif args.command == "start":
-        if server.start(env_seed=env_seed, env_host=env_host):
+        if server.start(
+            env_seed=env_seed,
+            env_host=env_host,
+            env_ca_key_file=env_ca_key_file,
+            env_ca_cert_file=env_ca_cert_file,
+        ):
             return 0
         else:
             print("CA server failed to start", file=sys.stderr)

--- a/upki_ca/connectors/zmq_register.py
+++ b/upki_ca/connectors/zmq_register.py
@@ -87,6 +87,7 @@ class ZMQRegister(Listener):
         seed = params.get("seed", "")
         cn = params.get("cn", "")
         profile = params.get("profile", "ra")
+        sans: list[dict[str, str]] | None = params.get("sans")
 
         # Validate seed
         if seed != self._seed:
@@ -106,7 +107,7 @@ class ZMQRegister(Listener):
 
         if self._authority is not None:
             try:
-                cert = self._authority.generate_certificate(cn, profile)
+                cert = self._authority.generate_certificate(cn, profile, sans=sans)
 
                 # Retrieve the private key that generate_certificate stored
                 key_bytes = (


### PR DESCRIPTION
This pull request introduces support for importing an existing CA private key and certificate during server initialization, and adds the ability to pass Subject Alternative Names (SANs) when generating certificates. These enhancements improve flexibility for initial setup and certificate issuance.

**CA server initialization improvements:**
* Added support for specifying existing CA key and certificate files via the `UPKI_CA_KEY_FILE` and `UPKI_CA_CERT_FILE` environment variables, allowing the server to import these on first boot instead of generating new ones. (`ca_server.py`) [[1]](diffhunk://#diff-b0a94ed9f1345daa5b551d46035f79c1a3143f1ecd77cd3e685216b417029dacR257-R258) [[2]](diffhunk://#diff-b0a94ed9f1345daa5b551d46035f79c1a3143f1ecd77cd3e685216b417029dacR278-R283) [[3]](diffhunk://#diff-b0a94ed9f1345daa5b551d46035f79c1a3143f1ecd77cd3e685216b417029dacL290-R304) [[4]](diffhunk://#diff-b0a94ed9f1345daa5b551d46035f79c1a3143f1ecd77cd3e685216b417029dacR440-R441) [[5]](diffhunk://#diff-b0a94ed9f1345daa5b551d46035f79c1a3143f1ecd77cd3e685216b417029dacL487-R508)

**Certificate issuance enhancements:**
* Updated the registration process to accept a `sans` parameter and pass it through to certificate generation, enabling SANs to be included in issued certificates. (`upki_ca/connectors/zmq_register.py`) [[1]](diffhunk://#diff-cd9745a2f1b39ed8e52d9702428fbbbcfe3c41d50065133bdfddff8d2daa6bb2R90) [[2]](diffhunk://#diff-cd9745a2f1b39ed8e52d9702428fbbbcfe3c41d50065133bdfddff8d2daa6bb2L109-R110)