### PR TITLE
fix(ci): Correct deps install using group lint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install poetry
-          poetry install --no-root --with dev
+          poetry install --no-root --with dev,lint
 
       - name: Run linter
         run: |
-          poetry run ruff check .
+          poetry run ruff check upki_ca/ tests/
 
       - name: Run tests
         run: |


### PR DESCRIPTION
This pull request makes minor improvements to the release workflow by enhancing dependency installation and refining the linter command.

- Workflow improvements:
  * In `.github/workflows/release.yml`, the Poetry install step now includes both `dev` and `lint` dependency groups, ensuring all necessary dependencies for development and linting are installed.
  * The linter command is updated to run `ruff` only on the `upki_ca/` and `tests/` directories, instead of the entire project, making linting more targeted.